### PR TITLE
chore(prepare-commit-msg): add a script to the merge skip hook

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,12 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+if [ "${COMMIT_SOURCE}" = merge ];then
+    exit 0
+fi
+
 exec < /dev/tty && npx cz --hook || true


### PR DESCRIPTION
adds a script so that commitzen is not triggered when a merge is performed